### PR TITLE
fix(app/docs): update github url organisation name

### DIFF
--- a/app/docs/_components/ComponentHeader.tsx
+++ b/app/docs/_components/ComponentHeader.tsx
@@ -30,7 +30,7 @@ export function ComponentHeader({
             <div className="flex flex-wrap gap-4 pt-2">
               {githubPath && (
                 <Link
-                  href={`https://github.com/rigidui/rigidui/blob/main/${githubPath}`}
+                  href={`https://github.com/FgrReloaded/rigidui/blob/main/${githubPath}`}
                   target="_blank"
                   className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
                 >


### PR DESCRIPTION
Thank you for creating such amazing UIs.

I found that all view source URLs are broken

For example
```
https://github.com/rigidui/rigidui/blob/main/registry/new-york/location-picker/location-picker.tsx
```

The correct URL should be
```
https://github.com/FgrReloaded/rigidui/blob/main/registry/new-york/location-picker/location-picker.tsx
```

```diff
- rigidui/rigidui
+ FgrReloaded/rigidui
```

This PR is aimed at fixing this issue by correcting the GitHub organisation name to the new one (aka `FgrReloaded`)
